### PR TITLE
Buildinfo UI - initial design and first iteration

### DIFF
--- a/src/api/app/assets/javascripts/webui/application.js
+++ b/src/api/app/assets/javascripts/webui/application.js
@@ -39,6 +39,7 @@
 //= require webui/autocomplete.js
 //= require webui/comment.js
 //= require webui/request.js
+//= require webui/buildinfo.js
 //= require webui/buildresult.js
 //= require webui/job_history.js
 //= require webui/package-view_file.js

--- a/src/api/app/assets/javascripts/webui/buildinfo.js
+++ b/src/api/app/assets/javascripts/webui/buildinfo.js
@@ -39,8 +39,8 @@ function normalizeData() {
       packages.push(new Package(pkgName, pkgSource, requiredBy));
       distinctRepositories.add(pkgSource);
       const elementHtml = directDependencies.includes(requiredBy) ?
-        pkgName + ' <small>[' + pkgSource + ']</small> << <span class="badge badge-secondary">' + requiredBy + '</span>' :
-        pkgName + ' <small>[' + pkgSource + ']</small> << ' + requiredBy;
+        '<code><u>' + requiredBy + '</u></code> <i>requires</i> <code>' + pkgName + '</code> <small class="badge badge-primary">' + pkgSource + '</small>' :
+        '<code>' + requiredBy + '</code> <i>requires</i> <code>' + pkgName + '</code> <small class="badge badge-primary">' + pkgSource + '</small>';
       chainedDependencies += '<div>' + elementHtml + '</div>';
     });
     return chainedDependencies;

--- a/src/api/app/assets/javascripts/webui/buildinfo.js
+++ b/src/api/app/assets/javascripts/webui/buildinfo.js
@@ -1,30 +1,27 @@
-class Package {
-  constructor(name, sources, requiredBy) {
-    this.name = name;
-    this.sources = sources;
-    this.requiredBy = requiredBy;
-  }
+function Package(name, sources, requiredBy) {
+  return {
+    name: name,
+    sources: sources,
+    requiredBy: requiredBy
+  };
 }
 
 // utility classes to generate HTML
 function th(content) {
-  return `<th>${content}</th>`;
+  return '<th>' + content + '</th>';
 }
 function tableHead() {
-  let content = '';
-  for (let i = 0; i < arguments.length; i++) {
+  var content = '';
+  for (var i = 0; i < arguments.length; i++) {
     content += th(arguments[i]);
   }
-  return `
-    <thead>
-      ${row(content)}
-    </thead>`;
+  return '<thead>' + row(content) + '</thead>';
 }
 function col(htmlContent, styleClass) {
-  return `<td class="${styleClass}">${htmlContent}</td>`;
+  return '<td class="' + styleClass + '">' + htmlContent + '</td>';
 }
 function row(htmlContent) {
-  return `<tr>${htmlContent}</tr>`;
+  return '<tr>' + htmlContent + '</tr>';
 }
 
 // main
@@ -32,15 +29,15 @@ function normalizeData() {
   var rawData = $('#build-info-raw-data').text();
 
   // relevant entities to compute on
-  const _PACKAGES = [];
-  const _DISTINCT_SOURCES = new Set();
-  let _DIRECT_DEPENDENCIES;
+  var _PACKAGES = [];
+  var _DISTINCT_SOURCES = new Set();
+  var _DIRECT_DEPENDENCIES;
 
   // encoding and shaping newline properly
   var normalizedData = rawData.replace(/\\n/g, '\n');
   normalizedData = normalizedData.replace(/\",/g, '",\n');
 
-  const errorMessage = normalizedData.match(/\"error\"\=\>\"(.*)\"/)[1];
+  var errorMessage = normalizedData.match(/\"error\"\=\>\"(.*)\"/)[1];
   $('#error-message').text(errorMessage); // summary
 
   _DIRECT_DEPENDENCIES = normalizedData.match(/expand args: (.*)/)[1].split(' ');
@@ -48,38 +45,40 @@ function normalizeData() {
 
   // populate the dependencies table
   $('#dependency-relationship').html(() => {
-    let chainedDependenciesHtml = `<table>${tableHead('who', 'requires', 'what', 'from')}`;
+    var chainedDependenciesHtml = '<table>' + tableHead('who', 'requires', 'what', 'from');
     normalizedData.match(/added (.*) because of (.*)/g)
       .forEach(element => {
-        const matchingGroupsForAddedPackages = element.match(/added (.*) because of (.*)/);
+        var matchingGroupsForAddedPackages = element.match(/added (.*) because of (.*)/);
         if (matchingGroupsForAddedPackages.length > 0) {
-          const extendedPackageName = matchingGroupsForAddedPackages[1];
-          const pkgName = extendedPackageName.split('@')[0];
-          const pkgSource = extendedPackageName.split('@')[1];
-          const requiredBy = matchingGroupsForAddedPackages[2];//.replace('(direct):', '');
+          var extendedPackageName = matchingGroupsForAddedPackages[1];
+          var pkgName = extendedPackageName.split('@')[0];
+          var pkgSource = extendedPackageName.split('@')[1];
+          var requiredBy = matchingGroupsForAddedPackages[2];//.replace('(direct):', '');
 
           // deduplicate packages
           if (_PACKAGES.filter(p => p.name === pkgName).length > 0) {
-            const package = _PACKAGES.find(p => p.name === pkgName);
+            var package = _PACKAGES.find(p => p.name === pkgName);
             package.requiredBy.push(requiredBy);
             package.sources.push(pkgSource);
           }
           else {
-            _PACKAGES.push(new Package(pkgName, [pkgSource], [requiredBy]));
+            _PACKAGES.push(Package(pkgName, [pkgSource], [requiredBy]));
           }
 
           _DISTINCT_SOURCES.add(pkgSource); // keep track of distinct sources
 
           chainedDependenciesHtml +=
             row(
-              (_DIRECT_DEPENDENCIES.includes(requiredBy) ? col(`<strong>${requiredBy}</strong>`) : col(requiredBy)) +
+              (_DIRECT_DEPENDENCIES.includes(requiredBy) ?
+                col('<strong>' + requiredBy + '</strong>')
+                : col(requiredBy)) +
               col('-->', 'text-center') +
               col(pkgName) +
-              col(`<span class="text-info">${pkgSource}</span>`)
+              col('<span class="text-info">' + pkgSource + '</span>')
             );
         }
     });
-    if (_PACKAGES.length == 0) {
+    if (_PACKAGES.length === 0) {
       chainedDependenciesHtml += row(col('no packages found'));
     }
     chainedDependenciesHtml += '</table>';
@@ -89,15 +88,16 @@ function normalizeData() {
 
   // populate project sources and packages
   $('#sources').html(() => {
-    let sourcesHtml = '';
+    var sourcesHtml = '';
     _DISTINCT_SOURCES.forEach(source => {
-      const packagesSubset = _PACKAGES.filter(p => p.sources.includes(source));
-      sourcesHtml += `<div class="text-info source-name collapsed">${source} (${packagesSubset.length})</div>`
-      sourcesHtml += `<ul class="source-package-list collapsed">`
+      var packagesSubset = _PACKAGES.filter(p => p.sources.includes(source));
+      sourcesHtml += '<div class="text-info source-name collapsed">' +
+          source + ' (' + packagesSubset.length + ')</div>';
+      sourcesHtml += '<ul class="source-package-list collapsed">';
       packagesSubset.forEach(package => {
-          sourcesHtml += `<li>${package.name}</li>`
+          sourcesHtml += '<li>' + package.name + '</li>';
         });
-        sourcesHtml += `</ul>`;
+        sourcesHtml += '</ul>';
     });
     return sourcesHtml;
   });
@@ -109,8 +109,11 @@ function normalizeData() {
   });
   $('#show-raw-data').on('click', function() {
     $('#build-info-raw-data').toggleClass('collapsed');
-    $('#build-info-raw-data').hasClass('collapsed') ?
-      $(this).text('show raw data') :
+    if ($('#build-info-raw-data').hasClass('collapsed')) {
+      $(this).text('show raw data');
+    }
+    else {
       $(this).text('hide raw data');
+    }
   });
 }

--- a/src/api/app/assets/javascripts/webui/buildinfo.js
+++ b/src/api/app/assets/javascripts/webui/buildinfo.js
@@ -59,8 +59,16 @@ function normalizeData() {
       const pkgSource = extendedPackageName.split('@')[1];
       const requiredBy = matchingGroups[2].replace('(direct):', '');
 
-      packages.push(new Package(pkgName, pkgSource, requiredBy));
+      if (packages.filter(p => p.name === pkgName).length > 0) {
+        const package = packages.find(p => p.name === pkgName);
+        package.requiredBy.push(requiredBy);
+      }
+      else {
+        packages.push(new Package(pkgName, pkgSource, [requiredBy]));
+      }
+
       distinctSources.add(pkgSource);
+
       chainedDependencies +=
         row(
           (directDependencies.includes(requiredBy) ?

--- a/src/api/app/assets/javascripts/webui/buildinfo.js
+++ b/src/api/app/assets/javascripts/webui/buildinfo.js
@@ -6,6 +6,27 @@ class Package {
   }
 }
 
+function th(content) {
+  return `<th>${content}</th>`;
+}
+function tableHead() {
+  let content = '';
+  for (let i = 0; i < arguments.length; i++) {
+    content += th(arguments[i]);
+  }
+  return `
+    <thead>
+      ${row(content)}
+    </thead>`;
+}
+function col(htmlContent) {
+  return `<td>${htmlContent}</td>`;
+}
+
+function row(htmlContent) {
+  return `<tr>${htmlContent}</tr>`;
+}
+
 function normalizeData() {
   var rawData = $('#build-info-raw-data').text();
 
@@ -29,15 +50,7 @@ function normalizeData() {
   const distinctRepositories = new Set();
   $('#build-info-chained-dependencies').html(() => {
     let chainedDependencies =
-      `<table>
-        <thead>
-          <tr>
-            <th>package name</th>
-            <th>requires</th>
-            <th>dependency name</th>
-            <th>repository</th>
-            </tr>
-          </thead>`;
+      `<table>${tableHead('package name', 'requires', 'dependency name', 'repository')}`;
     normalizedData.match(/added (.*) because of (.*)/g).forEach(element => {
       const matchingGroups = element.match(/added (.*) because of (.*)/);
       const extendedPackageName = matchingGroups[1];
@@ -47,17 +60,14 @@ function normalizeData() {
 
       packages.push(new Package(pkgName, pkgSource, requiredBy));
       distinctRepositories.add(pkgSource);
-      const elementHtml = directDependencies.includes(requiredBy) ?
-        `<td><strong>${requiredBy}</strong></td>
-        <td>--></td>
-        <td>${pkgName}</td>
-        <td><span class="badge badge-primary">${pkgSource}</span></td>`
-        :
-        `<td>${requiredBy}</td>
-        <td>--></td>
-        <td>${pkgName}</td>
-        <td><span class="badge badge-primary">${pkgSource}</span></td>`;
-      chainedDependencies += '<tr>' + elementHtml + '</tr>';
+      chainedDependencies +=
+        row(
+          (directDependencies.includes(requiredBy) ?
+            col(`<strong>${requiredBy}</strong>`) : col(requiredBy)) +
+          col('-->') +
+          col(pkgName) +
+          col(`<span class="badge badge-primary">${pkgSource}</span>`)
+        );
     });
     chainedDependencies += '</table>';
     return chainedDependencies;

--- a/src/api/app/assets/javascripts/webui/buildinfo.js
+++ b/src/api/app/assets/javascripts/webui/buildinfo.js
@@ -39,13 +39,6 @@ function normalizeData() {
 
   const directDependencies = normalizedData.match(/expand args: (.*)/)[1].split(' ');
   $('#count-direct-dependencies').text(directDependencies.length);
-  $('#build-info-direct-dependencies').html(() => {
-    let deps = "";
-    directDependencies.forEach(element => {
-      deps += '<span class="badge badge-secondary">' + element + '</span>&nbsp;'
-    });
-    return deps;
-  });
 
   const packages = [];
   const distinctSources = new Set();

--- a/src/api/app/assets/javascripts/webui/buildinfo.js
+++ b/src/api/app/assets/javascripts/webui/buildinfo.js
@@ -74,4 +74,18 @@ function normalizeData() {
     return chainedDependencies;
   });
   $('#count-total-dependencies').text(packages.length);
+
+  $('#sources').html(() => {
+    let sourcesHtml = '';
+    distinctSources.forEach(source => {
+      sourcesHtml += `<div class="font-weight-bold">${source}</div>`
+      sourcesHtml += `<ul>`
+      packages.filter(p => p.source == source)
+        .forEach(package => {
+          sourcesHtml += `<li>${package.name}</li>`
+        });
+        sourcesHtml += `</ul>`;
+    });
+    return sourcesHtml;
+  });
 }

--- a/src/api/app/assets/javascripts/webui/buildinfo.js
+++ b/src/api/app/assets/javascripts/webui/buildinfo.js
@@ -1,0 +1,21 @@
+function normalizeData() {
+  var rawData = $('#build-info-raw-data').text();
+
+  // encoding and shaping newline properly
+  var normalizedData = rawData.replace(/\\n/g, '\n');
+  normalizedData = normalizedData.replace(/\",/g, '",\n');
+
+  const errorMessage = normalizedData.match(/\"error\"\=\>\"(.*)\"/)[1];
+  $('#build-info-error-message').text(errorMessage);
+
+  const directDependencies = normalizedData.match(/expand args: (.*)/)[1];
+  $('#build-info-direct-dependencies').text(directDependencies);
+
+  $('#build-info-chained-dependencies').html(() => {
+    let chainedDependencies = "";
+    normalizedData.match(/added (.*) because of (.*)/g).forEach(element => {
+      chainedDependencies += '<div>' + element + '</div>';
+    });
+    return chainedDependencies;
+  });
+}

--- a/src/api/app/assets/javascripts/webui/buildinfo.js
+++ b/src/api/app/assets/javascripts/webui/buildinfo.js
@@ -19,8 +19,8 @@ function tableHead() {
       ${row(content)}
     </thead>`;
 }
-function col(htmlContent) {
-  return `<td>${htmlContent}</td>`;
+function col(htmlContent, styleClass) {
+  return `<td class="${styleClass}">${htmlContent}</td>`;
 }
 
 function row(htmlContent) {
@@ -42,15 +42,15 @@ function normalizeData() {
 
   const packages = [];
   const distinctSources = new Set();
-  $('#build-info-chained-dependencies').html(() => {
+  $('#dependency-relationship').html(() => {
     let chainedDependencies =
-      `<table>${tableHead('package name', 'requires', 'dependency name', 'repository')}`;
+      `<table>${tableHead('who', 'requires', 'what', 'from')}`;
     normalizedData.match(/added (.*) because of (.*)/g).forEach(element => {
       const matchingGroups = element.match(/added (.*) because of (.*)/);
       const extendedPackageName = matchingGroups[1];
       const pkgName = extendedPackageName.split('@')[0];
       const pkgSource = extendedPackageName.split('@')[1];
-      const requiredBy = matchingGroups[2].replace('(direct):', '');
+      const requiredBy = matchingGroups[2];//.replace('(direct):', '');
 
       if (packages.filter(p => p.name === pkgName).length > 0) {
         const package = packages.find(p => p.name === pkgName);
@@ -66,7 +66,7 @@ function normalizeData() {
         row(
           (directDependencies.includes(requiredBy) ?
             col(`<strong>${requiredBy}</strong>`) : col(requiredBy)) +
-          col('-->') +
+          col('-->', 'text-center') +
           col(pkgName) +
           col(`<span class="badge badge-primary">${pkgSource}</span>`)
         );

--- a/src/api/app/assets/javascripts/webui/buildinfo.js
+++ b/src/api/app/assets/javascripts/webui/buildinfo.js
@@ -28,7 +28,16 @@ function normalizeData() {
   const packages = [];
   const distinctRepositories = new Set();
   $('#build-info-chained-dependencies').html(() => {
-    let chainedDependencies = "";
+    let chainedDependencies =
+      `<table>
+        <thead>
+          <tr>
+            <th>package name</th>
+            <th>requires</th>
+            <th>dependency name</th>
+            <th>repository</th>
+            </tr>
+          </thead>`;
     normalizedData.match(/added (.*) because of (.*)/g).forEach(element => {
       const matchingGroups = element.match(/added (.*) because of (.*)/);
       const extendedPackageName = matchingGroups[1];
@@ -39,10 +48,18 @@ function normalizeData() {
       packages.push(new Package(pkgName, pkgSource, requiredBy));
       distinctRepositories.add(pkgSource);
       const elementHtml = directDependencies.includes(requiredBy) ?
-        '<code><u>' + requiredBy + '</u></code> <i>requires</i> <code>' + pkgName + '</code> <small class="badge badge-primary">' + pkgSource + '</small>' :
-        '<code>' + requiredBy + '</code> <i>requires</i> <code>' + pkgName + '</code> <small class="badge badge-primary">' + pkgSource + '</small>';
-      chainedDependencies += '<div>' + elementHtml + '</div>';
+        `<td><strong>${requiredBy}</strong></td>
+        <td>--></td>
+        <td>${pkgName}</td>
+        <td><span class="badge badge-primary">${pkgSource}</span></td>`
+        :
+        `<td>${requiredBy}</td>
+        <td>--></td>
+        <td>${pkgName}</td>
+        <td><span class="badge badge-primary">${pkgSource}</span></td>`;
+      chainedDependencies += '<tr>' + elementHtml + '</tr>';
     });
+    chainedDependencies += '</table>';
     return chainedDependencies;
   });
 

--- a/src/api/app/assets/javascripts/webui/buildinfo.js
+++ b/src/api/app/assets/javascripts/webui/buildinfo.js
@@ -48,7 +48,7 @@ function normalizeData() {
   });
 
   const packages = [];
-  const distinctRepositories = new Set();
+  const distinctSources = new Set();
   $('#build-info-chained-dependencies').html(() => {
     let chainedDependencies =
       `<table>${tableHead('package name', 'requires', 'dependency name', 'repository')}`;
@@ -60,7 +60,7 @@ function normalizeData() {
       const requiredBy = matchingGroups[2].replace('(direct):', '');
 
       packages.push(new Package(pkgName, pkgSource, requiredBy));
-      distinctRepositories.add(pkgSource);
+      distinctSources.add(pkgSource);
       chainedDependencies +=
         row(
           (directDependencies.includes(requiredBy) ?
@@ -74,12 +74,4 @@ function normalizeData() {
     return chainedDependencies;
   });
   $('#count-total-dependencies').text(packages.length);
-
-  $('#build-info-repositories').html(() => {
-    let distinctRepositoriesHtml = '';
-    Array.from(distinctRepositories).forEach(repo => {
-      distinctRepositoriesHtml += '<div class="badge badge-primary">' + repo + '</div>&nbsp;';
-    });
-    return distinctRepositoriesHtml;
-  });
 }

--- a/src/api/app/assets/javascripts/webui/buildinfo.js
+++ b/src/api/app/assets/javascripts/webui/buildinfo.js
@@ -90,8 +90,15 @@ function normalizeData() {
     return sourcesHtml;
   });
 
+  // `on click` events
   $('.source-name').on('click', function() {
     $(this).toggleClass('collapsed');
     $(this).next('.source-package-list').toggleClass('collapsed');
-  })
+  });
+  $('#show-raw-data').on('click', function() {
+    $('#build-info-raw-data').toggleClass('collapsed');
+    $('#build-info-raw-data').hasClass('collapsed') ?
+      $(this).text('show raw data') :
+      $(this).text('hide raw data');
+  });
 }

--- a/src/api/app/assets/javascripts/webui/buildinfo.js
+++ b/src/api/app/assets/javascripts/webui/buildinfo.js
@@ -1,7 +1,7 @@
 class Package {
-  constructor(name, source, requiredBy) {
+  constructor(name, sources, requiredBy) {
     this.name = name;
-    this.source = source;
+    this.sources = sources;
     this.requiredBy = requiredBy;
   }
 }
@@ -55,9 +55,10 @@ function normalizeData() {
       if (packages.filter(p => p.name === pkgName).length > 0) {
         const package = packages.find(p => p.name === pkgName);
         package.requiredBy.push(requiredBy);
+        package.sources.push(pkgSource);
       }
       else {
-        packages.push(new Package(pkgName, pkgSource, [requiredBy]));
+        packages.push(new Package(pkgName, [pkgSource], [requiredBy]));
       }
 
       distinctSources.add(pkgSource);
@@ -79,10 +80,10 @@ function normalizeData() {
   $('#sources').html(() => {
     let sourcesHtml = '';
     distinctSources.forEach(source => {
-      sourcesHtml += `<div class="font-weight-bold source-name collapsed">${source}</div>`
+      const packagesSubset = packages.filter(p => p.sources.includes(source));
+      sourcesHtml += `<div class="font-weight-bold source-name collapsed">${source} (${packagesSubset.length})</div>`
       sourcesHtml += `<ul class="source-package-list collapsed">`
-      packages.filter(p => p.source == source)
-        .forEach(package => {
+      packagesSubset.forEach(package => {
           sourcesHtml += `<li>${package.name}</li>`
         });
         sourcesHtml += `</ul>`;

--- a/src/api/app/assets/javascripts/webui/buildinfo.js
+++ b/src/api/app/assets/javascripts/webui/buildinfo.js
@@ -35,9 +35,10 @@ function normalizeData() {
   normalizedData = normalizedData.replace(/\",/g, '",\n');
 
   const errorMessage = normalizedData.match(/\"error\"\=\>\"(.*)\"/)[1];
-  $('#build-info-error-message').text(errorMessage);
+  $('#error-message').text(errorMessage);
 
   const directDependencies = normalizedData.match(/expand args: (.*)/)[1].split(' ');
+  $('#count-direct-dependencies').text(directDependencies.length);
   $('#build-info-direct-dependencies').html(() => {
     let deps = "";
     directDependencies.forEach(element => {
@@ -72,6 +73,7 @@ function normalizeData() {
     chainedDependencies += '</table>';
     return chainedDependencies;
   });
+  $('#count-total-dependencies').text(packages.length);
 
   $('#build-info-repositories').html(() => {
     let distinctRepositoriesHtml = '';

--- a/src/api/app/assets/javascripts/webui/buildinfo.js
+++ b/src/api/app/assets/javascripts/webui/buildinfo.js
@@ -86,8 +86,8 @@ function normalizeData() {
   $('#sources').html(() => {
     let sourcesHtml = '';
     distinctSources.forEach(source => {
-      sourcesHtml += `<div class="font-weight-bold">${source}</div>`
-      sourcesHtml += `<ul>`
+      sourcesHtml += `<div class="font-weight-bold source-name collapsed">${source}</div>`
+      sourcesHtml += `<ul class="source-package-list collapsed">`
       packages.filter(p => p.source == source)
         .forEach(package => {
           sourcesHtml += `<li>${package.name}</li>`
@@ -96,4 +96,9 @@ function normalizeData() {
     });
     return sourcesHtml;
   });
+
+  $('.source-name').on('click', function() {
+    $(this).toggleClass('collapsed');
+    $(this).next('.source-package-list').toggleClass('collapsed');
+  })
 }

--- a/src/api/app/assets/stylesheets/webui/application.scss
+++ b/src/api/app/assets/stylesheets/webui/application.scss
@@ -32,6 +32,7 @@
 @import 'coderay';
 @import 'system-status';
 @import 'texts';
+@import 'build-info';
 @import 'build-results';
 @import 'autocomplete';
 @import 'package-attributes';

--- a/src/api/app/assets/stylesheets/webui/build-info.scss
+++ b/src/api/app/assets/stylesheets/webui/build-info.scss
@@ -1,0 +1,9 @@
+#build-info-raw-data.collapsed {
+  display: none;
+}
+#show-raw-data {
+  cursor: default;
+}
+#show-raw-data:hover {
+  text-decoration: underline;
+}

--- a/src/api/app/assets/stylesheets/webui/build-info.scss
+++ b/src/api/app/assets/stylesheets/webui/build-info.scss
@@ -15,6 +15,9 @@ table {
 td, tr {
   border: 1px solid #ccc;
 }
+td, th {
+  padding: .2em .4em;
+}
 thead {
   background-color: #eee;
 }

--- a/src/api/app/assets/stylesheets/webui/build-info.scss
+++ b/src/api/app/assets/stylesheets/webui/build-info.scss
@@ -1,9 +1,11 @@
 #build-info-raw-data.collapsed {
   display: none;
 }
+
 #show-raw-data {
   cursor: default;
 }
+
 #show-raw-data:hover {
   text-decoration: underline;
 }
@@ -12,29 +14,34 @@ table {
   border-collapse: collapse;
   width: 100%;
 }
+
 td, tr {
   border: 1px solid #ccc;
 }
+
 td, th {
   padding: .2em .4em;
 }
+
 thead {
   background-color: #eee;
 }
-
 
 .source-name:hover {
   text-decoration: underline;
   color: #666;
   cursor: default;
 }
+
 .source-name::before {
-  content: '-';
+  content: "-";
   margin-right: .5em;
 }
+
 .source-name.collapsed:before {
-  content: '+';
+  content: "+";
 }
+
 .source-package-list.collapsed {
   display: none;
 }

--- a/src/api/app/assets/stylesheets/webui/build-info.scss
+++ b/src/api/app/assets/stylesheets/webui/build-info.scss
@@ -7,3 +7,14 @@
 #show-raw-data:hover {
   text-decoration: underline;
 }
+
+table {
+  border-collapse: collapse;
+  width: 100%;
+}
+td, tr {
+  border: 1px solid #ccc;
+}
+thead {
+  background-color: #eee;
+}

--- a/src/api/app/assets/stylesheets/webui/build-info.scss
+++ b/src/api/app/assets/stylesheets/webui/build-info.scss
@@ -18,3 +18,20 @@ td, tr {
 thead {
   background-color: #eee;
 }
+
+
+.source-name:hover {
+  text-decoration: underline;
+  color: #666;
+  cursor: default;
+}
+.source-name::before {
+  content: '-';
+  margin-right: .5em;
+}
+.source-name.collapsed:before {
+  content: '+';
+}
+.source-package-list.collapsed {
+  display: none;
+}

--- a/src/api/app/views/webui/packages/build_info/index.html.haml
+++ b/src/api/app/views/webui/packages/build_info/index.html.haml
@@ -6,7 +6,7 @@
     %h3
       = @pagetitle
     .row
-      %div.col-md-6
+      .col-md-6
         .card.mb-3
           .card-header
             %h5 Build Summary
@@ -34,9 +34,9 @@
               5
             %div
               %strong Errors:
-              %span#error-message.alert-error unresolvable: nothing provides _package_name_
+              %span.alert-error#error-message unresolvable: nothing provides _package_name_
 
-      %div.col-md-6
+      .col-md-6
         .card.mb-3
           .card-header
             %h5 Projects and Packages
@@ -52,7 +52,7 @@
                 %li rpm-build:libc.so.6()(64bit)
                 %li rpm-build:libc.so.6(GLIBC_2.3)(64bit)
 
-      %div.col-12
+      .col-12
         .card.mb-3
           .card-header
             %h5 Dependency relationship
@@ -76,7 +76,7 @@
         %br
         %div
           #show-raw-data show raw data
-          %code#build-info-raw-data.collapsed
+          %code.collapsed#build-info-raw-data
             = @buildinfo
 
 :javascript

--- a/src/api/app/views/webui/packages/build_info/index.html.haml
+++ b/src/api/app/views/webui/packages/build_info/index.html.haml
@@ -10,7 +10,7 @@
     %p
       %div
         %strong Error Message
-        %div#build-info-error-message
+        %div#build-info-error-message.alert-error
         %br
         %strong Direct dependencies
         %div#build-info-direct-dependencies

--- a/src/api/app/views/webui/packages/build_info/index.html.haml
+++ b/src/api/app/views/webui/packages/build_info/index.html.haml
@@ -39,37 +39,8 @@
     %p
       .card
         .card-header
-          %h5 Projects / Sources
+          %h5 Projects and Packages
         .card-body#sources
-          %div
-            .font-weight-bold - openSUSE.org:SUSE:SLE-15-SP3:GA/pool
-            %ul
-              %li perl:libc.so.6(GLIBC_2.2.5)(64bit)
-              %li perl:libc.so.6(GLIBC_2.4)(64bit)
-              %li perl:libc.so.6(GLIBC_2.3)(64bit)
-              %li perl:libpthread.so.0(GLIBC_2.3.2)(64bit)
-              %li rpm-build:libc.so.6()(64bit)
-              %li rpm-build:libc.so.6(GLIBC_2.3)(64bit)
-
-          %div
-            .font-weight-bold - openSUSE.org:SUSE:SLE-15-SP2:Update/pool-leap-15.3
-            %ul
-              %li perl:libc.so.6(GLIBC_2.2.5)(64bit)
-              %li perl:libc.so.6(GLIBC_2.4)(64bit)
-              %li perl:libc.so.6(GLIBC_2.3)(64bit)
-
-          %div
-            .font-weight-bold + openSUSE.org:SUSE:SLE-15:Update/pool-leap-15.3
-
-          %div
-            .font-weight-bold + openSUSE.org:SUSE:SLE-15-SP1:Update/pool-leap-15.3
-
-          %div
-            .font-weight-bold - openSUSE.org:SUSE:SLE-15:GA/pool
-            %ul
-              %li rpm-build:file
-              %li rpm-build:binutils
-
 
     %p
       %div

--- a/src/api/app/views/webui/packages/build_info/index.html.haml
+++ b/src/api/app/views/webui/packages/build_info/index.html.haml
@@ -41,12 +41,38 @@
         .card-header
           %h5 Projects and Packages
         .card-body#sources
+          -# template below
+          %div
+            .font-weight-bold - openSUSE.org:SUSE:SLE-15-SP3:GA/pool
+            %ul
+              %li perl:libc.so.6(GLIBC_2.2.5)(64bit)
+              %li perl:libc.so.6(GLIBC_2.4)(64bit)
+              %li perl:libc.so.6(GLIBC_2.3)(64bit)
+              %li perl:libpthread.so.0(GLIBC_2.3.2)(64bit)
+              %li rpm-build:libc.so.6()(64bit)
+              %li rpm-build:libc.so.6(GLIBC_2.3)(64bit)
 
     %p
-      %div
-        %strong Chained dependencies
-        %div#build-info-chained-dependencies
-
+      .card
+        .card-header
+          %h5 Dependency relationship
+        .card-body#dependency-relationship
+          -# template below
+          %table
+            %thead
+              %tr
+                %th who
+                %th.text-center requires
+                %th what
+                %th from
+            %tbody
+              %tr
+                %td
+                  (direct):perl
+                %td.text-center -->
+                %td perl
+                %td
+                  %span.badge.badge-primary openSUSE.org:SUSE:SLE-15-SP3:GA/pool
       %br
       %div
         #show-raw-data show raw data

--- a/src/api/app/views/webui/packages/build_info/index.html.haml
+++ b/src/api/app/views/webui/packages/build_info/index.html.haml
@@ -8,7 +8,27 @@
     %h6.subtitle
       Repository / Architecture: #{@repository.name} / #{@architecture}
     %p
-      %strong
-        Build Info:
-      %code
-        = @buildinfo
+      %div
+        %strong Error Message
+        %div#build-info-error-message
+        %br
+        %strong Direct dependencies
+        %div#build-info-direct-dependencies
+        %br
+        %strong Chained dependencies
+        %div#build-info-chained-dependencies
+
+      %br
+      %div
+        #show-raw-data show raw data
+        %code#build-info-raw-data.collapsed
+          = @buildinfo
+
+:javascript
+  normalizeData();
+  $('#show-raw-data').on('click', function() {
+    $('#build-info-raw-data').toggleClass('collapsed');
+    $('#build-info-raw-data').hasClass('collapsed') ?
+      $(this).text('show raw data') :
+      $(this).text('hide raw data');
+  });

--- a/src/api/app/views/webui/packages/build_info/index.html.haml
+++ b/src/api/app/views/webui/packages/build_info/index.html.haml
@@ -17,6 +17,9 @@
         %br
         %strong Chained dependencies
         %div#build-info-chained-dependencies
+        %br
+        %strong Repositories used
+        %div#build-info-repositories
 
       %br
       %div

--- a/src/api/app/views/webui/packages/build_info/index.html.haml
+++ b/src/api/app/views/webui/packages/build_info/index.html.haml
@@ -55,9 +55,3 @@
 
 :javascript
   normalizeData();
-  $('#show-raw-data').on('click', function() {
-    $('#build-info-raw-data').toggleClass('collapsed');
-    $('#build-info-raw-data').hasClass('collapsed') ?
-      $(this).text('show raw data') :
-      $(this).text('hide raw data');
-  });

--- a/src/api/app/views/webui/packages/build_info/index.html.haml
+++ b/src/api/app/views/webui/packages/build_info/index.html.haml
@@ -37,18 +37,47 @@
             %span#error-message.alert-error unresolvable: nothing provides _package_name_
 
     %p
+      .card
+        .card-header
+          %h5 Projects / Sources
+        .card-body#sources
+          %div
+            .font-weight-bold - openSUSE.org:SUSE:SLE-15-SP3:GA/pool
+            %ul
+              %li perl:libc.so.6(GLIBC_2.2.5)(64bit)
+              %li perl:libc.so.6(GLIBC_2.4)(64bit)
+              %li perl:libc.so.6(GLIBC_2.3)(64bit)
+              %li perl:libpthread.so.0(GLIBC_2.3.2)(64bit)
+              %li rpm-build:libc.so.6()(64bit)
+              %li rpm-build:libc.so.6(GLIBC_2.3)(64bit)
+
+          %div
+            .font-weight-bold - openSUSE.org:SUSE:SLE-15-SP2:Update/pool-leap-15.3
+            %ul
+              %li perl:libc.so.6(GLIBC_2.2.5)(64bit)
+              %li perl:libc.so.6(GLIBC_2.4)(64bit)
+              %li perl:libc.so.6(GLIBC_2.3)(64bit)
+
+          %div
+            .font-weight-bold + openSUSE.org:SUSE:SLE-15:Update/pool-leap-15.3
+
+          %div
+            .font-weight-bold + openSUSE.org:SUSE:SLE-15-SP1:Update/pool-leap-15.3
+
+          %div
+            .font-weight-bold - openSUSE.org:SUSE:SLE-15:GA/pool
+            %ul
+              %li rpm-build:file
+              %li rpm-build:binutils
+
+
+    %p
       %div
-        %strong Error Message
-        %div#build-info-error-message.alert-error
-        %br
         %strong Direct dependencies
         %div#build-info-direct-dependencies
         %br
         %strong Chained dependencies
         %div#build-info-chained-dependencies
-        %br
-        %strong Repositories used
-        %div#build-info-repositories
 
       %br
       %div

--- a/src/api/app/views/webui/packages/build_info/index.html.haml
+++ b/src/api/app/views/webui/packages/build_info/index.html.haml
@@ -5,8 +5,37 @@
   .card-body
     %h3
       = @pagetitle
-    %h6.subtitle
-      Repository / Architecture: #{@repository.name} / #{@architecture}
+
+    %p
+      .card
+        .card-header
+          %h5 Build Summary
+        .card-body
+          %div
+            %strong Package name:
+            #{@package.name}
+          %div
+            %strong Package description:
+            #{@package.description}
+          %div
+            %strong Repository:
+            .badge.badge-secondary #{@repository.name}
+          %div
+            %strong Architecture:
+            .badge.badge-primary #{@architecture}
+          %div
+            %strong Required Packages directly:
+            %span#count-direct-dependencies
+          %div
+            %strong Required Packages in total:
+            %span#count-total-dependencies
+          %div
+            %strong Project/Repositories used:
+            5
+          %div
+            %strong Errors:
+            %span#error-message.alert-error unresolvable: nothing provides _package_name_
+
     %p
       %div
         %strong Error Message

--- a/src/api/app/views/webui/packages/build_info/index.html.haml
+++ b/src/api/app/views/webui/packages/build_info/index.html.haml
@@ -5,79 +5,79 @@
   .card-body
     %h3
       = @pagetitle
+    .row
+      %div.col-md-6
+        .card.mb-3
+          .card-header
+            %h5 Build Summary
+          .card-body
+            %div
+              %strong Package name:
+              #{@package.name}
+            %div
+              %strong Package description:
+              #{@package.description}
+            %div
+              %strong Repository:
+              .badge.badge-secondary #{@repository.name}
+            %div
+              %strong Architecture:
+              .badge.badge-primary #{@architecture}
+            %div
+              %strong Required Packages directly:
+              %span#count-direct-dependencies
+            %div
+              %strong Required Packages in total:
+              %span#count-total-dependencies
+            %div
+              %strong Project/Repositories used:
+              5
+            %div
+              %strong Errors:
+              %span#error-message.alert-error unresolvable: nothing provides _package_name_
 
-    %p
-      .card
-        .card-header
-          %h5 Build Summary
-        .card-body
-          %div
-            %strong Package name:
-            #{@package.name}
-          %div
-            %strong Package description:
-            #{@package.description}
-          %div
-            %strong Repository:
-            .badge.badge-secondary #{@repository.name}
-          %div
-            %strong Architecture:
-            .badge.badge-primary #{@architecture}
-          %div
-            %strong Required Packages directly:
-            %span#count-direct-dependencies
-          %div
-            %strong Required Packages in total:
-            %span#count-total-dependencies
-          %div
-            %strong Project/Repositories used:
-            5
-          %div
-            %strong Errors:
-            %span#error-message.alert-error unresolvable: nothing provides _package_name_
+      %div.col-md-6
+        .card.mb-3
+          .card-header
+            %h5 Projects and Packages
+          .card-body#sources
+            -# template below
+            %div
+              .text-info - openSUSE.org:SUSE:SLE-15-SP3:GA/pool
+              %ul
+                %li perl:libc.so.6(GLIBC_2.2.5)(64bit)
+                %li perl:libc.so.6(GLIBC_2.4)(64bit)
+                %li perl:libc.so.6(GLIBC_2.3)(64bit)
+                %li perl:libpthread.so.0(GLIBC_2.3.2)(64bit)
+                %li rpm-build:libc.so.6()(64bit)
+                %li rpm-build:libc.so.6(GLIBC_2.3)(64bit)
 
-    %p
-      .card
-        .card-header
-          %h5 Projects and Packages
-        .card-body#sources
-          -# template below
-          %div
-            .font-weight-bold - openSUSE.org:SUSE:SLE-15-SP3:GA/pool
-            %ul
-              %li perl:libc.so.6(GLIBC_2.2.5)(64bit)
-              %li perl:libc.so.6(GLIBC_2.4)(64bit)
-              %li perl:libc.so.6(GLIBC_2.3)(64bit)
-              %li perl:libpthread.so.0(GLIBC_2.3.2)(64bit)
-              %li rpm-build:libc.so.6()(64bit)
-              %li rpm-build:libc.so.6(GLIBC_2.3)(64bit)
-
-    %p
-      .card
-        .card-header
-          %h5 Dependency relationship
-        .card-body#dependency-relationship
-          -# template below
-          %table
-            %thead
-              %tr
-                %th who
-                %th.text-center requires
-                %th what
-                %th from
-            %tbody
-              %tr
-                %td
-                  (direct):perl
-                %td.text-center -->
-                %td perl
-                %td
-                  %span.badge.badge-primary openSUSE.org:SUSE:SLE-15-SP3:GA/pool
-      %br
-      %div
-        #show-raw-data show raw data
-        %code#build-info-raw-data.collapsed
-          = @buildinfo
+      %div.col-12
+        .card.mb-3
+          .card-header
+            %h5 Dependency relationship
+          .card-body#dependency-relationship
+            -# template below
+            %table
+              %thead
+                %tr
+                  %th who
+                  %th.text-center requires
+                  %th what
+                  %th from
+              %tbody
+                %tr
+                  %td
+                    (direct):perl
+                  %td.text-center -->
+                  %td perl
+                  %td
+                    %span.badge.badge-primary openSUSE.org:SUSE:SLE-15-SP3:GA/pool
+        %br
+        %div
+          #show-raw-data show raw data
+          %code#build-info-raw-data.collapsed
+            = @buildinfo
 
 :javascript
   normalizeData();

--- a/src/api/app/views/webui/packages/build_info/index.html.haml
+++ b/src/api/app/views/webui/packages/build_info/index.html.haml
@@ -44,9 +44,6 @@
 
     %p
       %div
-        %strong Direct dependencies
-        %div#build-info-direct-dependencies
-        %br
         %strong Chained dependencies
         %div#build-info-chained-dependencies
 


### PR DESCRIPTION
https://github.com/openSUSE/open-build-service/issues/11694

Initial rendering of all the `build-info` available at `_buildinfo?debug=1` route.
Everything is computed and rendered after parsing the raw data served at that route.

This PR presents the data sliced by the following criteria:
- a summary box wrapping relevant but high level information about the build, including the message error
- a projects box listing all the projects used for the build, with an expand/collapse toggle of the list of the packages fetched from each project
- a dependency relationship box presenting the _who-requires-what-from where_ connection
- the raw data still available at the end of the page for a deeper debugging matter

The data are normalized and manipulated from the `buildinfo.js` (for the sake of this exercise), as they are already available in the content of the HTML. If this initial iteration will have a follow-up or a spin-off, we should first start thinking about providing data in a different shape on the backend side, and evaluating about serving the data maybe async or even in a lazy-lading behavior for the different pieces.

**Short-term**: the _dependency relationship_ table could optionally be represented as a tree starting from the _direct dependency_ triggered by the `spec` file, and indenting by levels of requirements the dependencies. A robust decoding of the names is required for that, as of now the debug build info comes in the shape of:
```
added perl-Regexp-Common@openSUSE.org:SUSE:SLE-15:GA/pool because of (direct):perl(Regexp::Common)
added glibc@openSUSE.org:SUSE:SLE-15-SP3:GA/pool because of perl:libc.so.6()(64bit)
```
At the moment the reverse logic is computed and in the page we have the data in the shape of:
```
(direct):perl(Regexp::Common) requires perl-Regexp-Common from openSUSE.org:SUSE:SLE-15:GA/pool
perl:libc.so.6()(64bit) requires glibc openSUSE.org:SUSE:SLE-15-SP3:GA/pool
```
Here `(direct):` stands for _it is a direct requirement_ triggered from the `spec` file, `perl:` instead means an intermediate dependency is occurring: `perl` --> `libc.so6()(64bit)` --> `glibc`, something that could be represented as a tree:
```
perl
   |___libc.so6()(64bit)
             |___ glibc
```

**Long-term**: due to the fact dependencies cannot be purely represented as a tree (even if it could already be a valuable representation) but it is more like a graph, an additional [d3.js](https://d3js.org/) implementation could be a very nice to have, something like https://www.jasondavies.com/d3-dependencies/


#### Below some screenshot:

- Before: only the raw data
- After:

Summary 
![build-info-1](https://user-images.githubusercontent.com/7080830/173353963-7c1478ab-d54b-4c03-afb4-2f43f805af03.png)

Expanded project sources
![build-info-2](https://user-images.githubusercontent.com/7080830/173353971-de14bc44-7ee8-458e-890d-f73ad8889b11.png)

Dependency relationship
![build-info-3](https://user-images.githubusercontent.com/7080830/173353973-b86c7978-8038-4e76-8c57-db32d013a65f.png)

Accessible raw data
![build-info-4](https://user-images.githubusercontent.com/7080830/173353978-f46b757f-50f7-4c81-bf34-6e7232aa7abb.png)
